### PR TITLE
#patch (1741) Nginx redirige vers le mobile quand le service webapp est down

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,6 +31,8 @@ services:
       - 80
     env_file:
       - ./config/.env
+    depends_on:
+      - rb_webapp
 
   rb_www:
     image: resorptionbidonvilles/www:${RB_WWW_VERSION}


### PR DESCRIPTION
ticket Trello : https://trello.com/c/kTGiiqun/1741-nginx-redirige-vers-le-mobile-quand-le-service-webapp-est-down