### PR TITLE
#patch (2177) Changer le bucket pour les copies de sauvegardes de BDD

### DIFF
--- a/config/rclone.conf.template
+++ b/config/rclone.conf.template
@@ -1,18 +1,19 @@
-[scaleway]
-type = s3
-provider = Scaleway
+[rb-s3-bucket]
+type = swift
 env_auth = false
-access_key_id = ${RB_REMOTEBACKUP_KEY_ID}
-secret_access_key = ${RB_REMOTEBACKUP_KEY_SECRET}
-region = fr-par
-endpoint = ${RB_REMOTEBACKUP_BUCKET_ENDPOINT}
-acl = private
-storage_class = STANDARD
+auth_version = 3
+auth = ${RB_REMOTEBACKUP_AUTH_URL}
+endpoint_type = public
+tenant_domain = default
+tenant = ${RB_REMOTEBACKUP_TENANT_ID}
+domain = default
+user = ${RB_REMOTEBACKUP_BUCKET_USERNAME}
+key = ${RB_REMOTEBACKUP_KEY_ID}
+region = SBG
 
 [secret]
 type = crypt
-remote = scaleway:${RB_REMOTEBACKUP_BUCKET_NAME}
+remote = rb-s3-bucket:${RB_REMOTEBACKUP_BUCKET_NAME}
 filename_encryption = off
 directory_name_encryption = false
-password = ${RB_REMOTEBACKUP_BUCKET_PASSWORD}
-
+password = ${RB_REMOTEBACKUP_KEY_SECRET}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,26 +8,25 @@ services:
   rb_proxy:
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
-  localstack:
-    container_name: localstack
-    image: localstack/localstack:latest
-    ports:
-      - "${RB_LOCALSTACK_EXTERNAL_PORT}:4566" # LocalStack Gateway
-      - "4510-4559:4510-4559" # external services port range
-    environment:
-      - EXTRA_CORS_ALLOWED_ORIGINS=app://.
-      - AWS_DEFAULT_REGION=us-east-1
-      - AWS_ACCESS_KEY_ID=test
-      - AWS_SECRET_ACCESS_KEY=test
-      - DEBUG=1
-      - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOSTNAME=localstack
-      - HOSTNAME_EXTERNAL=localstack
-      - SERVICES=lambda,s3
-      - DATA_DIR=/tmp/localstack/data
-    volumes:
-      - "${RB_LOCALSTACK_DATA_FOLDER:-/tmp/localstack}:/tmp/localstack"
-      - "/var/run/docker.sock:/var/run/docker.sock"
-    networks:
-      - rb_network
+  # localstack:
+  #   container_name: localstack
+  #   image: localstack/localstack:latest
+  #   ports:
+  #     - "${RB_LOCALSTACK_EXTERNAL_PORT}:4566" # LocalStack Gateway
+  #     - "4510-4559:4510-4559" # external services port range
+  #   environment:
+  #     - EXTRA_CORS_ALLOWED_ORIGINS=app://.
+  #     - AWS_DEFAULT_REGION=us-east-1
+  #     - AWS_ACCESS_KEY_ID=test
+  #     - AWS_SECRET_ACCESS_KEY=test
+  #     - DEBUG=1
+  #     - DOCKER_HOST=unix:///var/run/docker.sock
+  #     - HOSTNAME=localstack
+  #     - HOSTNAME_EXTERNAL=localstack
+  #     - SERVICES=lambda,s3
+  #     - DATA_DIR=/tmp/localstack/data
+  #   volumes:
+  #     - "${RB_LOCALSTACK_DATA_FOLDER:-/tmp/localstack}:/tmp/localstack"
+  #     - "/var/run/docker.sock:/var/run/docker.sock"
+  #   networks:
+  #     - rb_network


### PR DESCRIPTION
## 🧾 Ticket Trello
https://trello.com/c/tsAXjVNr/2177

## 🛠 Description de la PR
- Change les paramètres de connexion utiliser par `rclone` pour copier les fichiers de sauvegardes de la BDD vers un bucket situé dans un centre de données différent de celui qui héberge l'application (front et back)
- Met en commentaire les éléments permettant l'utilisation en mode dev d'une pile `localstack` pour gérer les pièces jointes

## 🚨 Notes pour la mise en production
- Les variables d'environnements doivent être mises à jour